### PR TITLE
Feature/login improvement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,8 @@ dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5'
     implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.50'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/tidify/tidify/common/Constants.java
+++ b/src/main/java/tidify/tidify/common/Constants.java
@@ -6,8 +6,8 @@ public class Constants {
     public static final long HOUR = 60 * MINUTE;
 
     public static final long DAY = 24 * HOUR;
-    public static final long TOKEN_VALID_TIME = DAY * 1000L;
-    public static final long REFRESH_TOKEN_VALID_TIME = 60 * DAY * 1000L; // 24시간
+    public static final long TOKEN_VALID_TIME = DAY * 1000L; // 24시간
+    public static final long REFRESH_TOKEN_VALID_TIME = 60 * DAY * 1000L; // 60일
 
     public static final String APPLE_AUTH_URL = "https://appleid.apple.com/auth/keys";
 }

--- a/src/main/java/tidify/tidify/config/RedisConfig.java
+++ b/src/main/java/tidify/tidify/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package tidify.tidify.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?,?> redisTemplate(){
+        RedisTemplate<byte[], byte[]> redisTemplate=new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/tidify/tidify/controller/OAuthController.java
+++ b/src/main/java/tidify/tidify/controller/OAuthController.java
@@ -21,7 +21,7 @@ public class OAuthController {
 
     private final AccountService userService;
 
-    @GetMapping("login/kakao") // TODO : url 수정 필요
+    @GetMapping("login")
     public Token getKakaoToken(@RequestParam(required = false) String code,
         @RequestParam(required = false) SocialType type,
         HttpServletRequest request) {

--- a/src/main/java/tidify/tidify/domain/User.java
+++ b/src/main/java/tidify/tidify/domain/User.java
@@ -24,6 +24,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Singular;
+import tidify.tidify.security.JwtTokenProvider;
 
 @Getter
 @Setter
@@ -138,5 +139,9 @@ public class User extends BaseEntity implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public void modifyRefreshToken(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
     }
 }

--- a/src/main/java/tidify/tidify/dto/Payload.java
+++ b/src/main/java/tidify/tidify/dto/Payload.java
@@ -18,6 +18,7 @@ public class Payload {
     private String is_private_email;
     private Long auth_time;
     private boolean nonce_supported;
+    private Integer real_user_status;
 
     @Override
     public String toString() {

--- a/src/main/java/tidify/tidify/dto/UserDto.java
+++ b/src/main/java/tidify/tidify/dto/UserDto.java
@@ -2,6 +2,7 @@ package tidify.tidify.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import tidify.tidify.security.Token;
 
 @Getter
 @AllArgsConstructor
@@ -10,4 +11,8 @@ public class UserDto {
     private String password;
     private String accessToken;
     private String refreshToken;
+
+    public static UserDto of(String email, String password, Token token) {
+        return new UserDto(email, password, token.getAccessToken(), token.getRefreshToken());
+    }
 }

--- a/src/main/java/tidify/tidify/repository/qdsl/BookmarkRepositoryImpl.java
+++ b/src/main/java/tidify/tidify/repository/qdsl/BookmarkRepositoryImpl.java
@@ -1,4 +1,4 @@
-package tidify.tidify.repository;
+package tidify.tidify.repository.qdsl;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,6 +18,7 @@ import tidify.tidify.domain.QFolder;
 import tidify.tidify.domain.User;
 import tidify.tidify.dto.BookmarkResponse;
 import tidify.tidify.dto.QBookmarkResponse;
+import tidify.tidify.repository.BookmarkRepositoryCustom;
 
 @RequiredArgsConstructor
 public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom {

--- a/src/main/java/tidify/tidify/repository/qdsl/FolderRepositoryImpl.java
+++ b/src/main/java/tidify/tidify/repository/qdsl/FolderRepositoryImpl.java
@@ -1,4 +1,4 @@
-package tidify.tidify.repository;
+package tidify.tidify.repository.qdsl;
 
 import java.util.List;
 
@@ -16,6 +16,7 @@ import tidify.tidify.domain.QFolder;
 import tidify.tidify.domain.User;
 import tidify.tidify.dto.FolderResponse;
 import tidify.tidify.dto.QFolderResponse;
+import tidify.tidify.repository.FolderRepositoryCustom;
 
 @RequiredArgsConstructor
 public class FolderRepositoryImpl implements FolderRepositoryCustom {

--- a/src/main/java/tidify/tidify/security/JwtTokenProvider.java
+++ b/src/main/java/tidify/tidify/security/JwtTokenProvider.java
@@ -150,6 +150,11 @@ public class JwtTokenProvider {
     }
 
     public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
-        response.setHeader("authorization", "bearer " + accessToken);
+        // response.setHeader("authorization", "bearer " + accessToken); // 기존
+        response.setHeader("X-AUTH-TOKEN", accessToken);
+    }
+
+    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
+        response.setHeader("refreshToken", refreshToken);
     }
 }

--- a/src/main/java/tidify/tidify/security/JwtTokenProvider.java
+++ b/src/main/java/tidify/tidify/security/JwtTokenProvider.java
@@ -23,7 +23,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.PostConstruct;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.util.Base64;
@@ -90,11 +89,6 @@ public class JwtTokenProvider {
         return Jwts.parser().setSigningKey(signingKey).parseClaimsJws(token).getBody().getSubject();
     }
 
-    // Request의 Header에서 token 값을 가져옵니다. "X-AUTH-TOKEN" : "TOKEN값'
-    public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("X-AUTH-TOKEN");
-    }
-
     // 토큰의 유효성 + 만료일자 확인
     public boolean validateToken(String jwtToken) {
         try {
@@ -114,25 +108,8 @@ public class JwtTokenProvider {
         }
     }
 
-    public String resolveRefreshToken(HttpServletRequest request) {
-        if (request.getHeader("refreshToken") != null) {
-            return request.getHeader("refreshToken");
-        }
-        return null;
-    }
-
-    // RefreshToken 존재유무 확인
     public boolean existsRefreshToken(String refreshToken) {
         return userRepository.existsByRefreshToken(refreshToken);
-    }
-
-    public User findUserByRefreshToken(String refreshToken) {
-        return userRepository.findUserByRefreshToken(refreshToken);
-    }
-
-    @Transactional
-    public void saveRefreshToken(User user) {
-        userRepository.save(user);
     }
 
     public String createAccessToken(String userName) {
@@ -149,12 +126,16 @@ public class JwtTokenProvider {
             .compact();
     }
 
-    public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
-        // response.setHeader("authorization", "bearer " + accessToken); // 기존
-        response.setHeader("X-AUTH-TOKEN", accessToken);
+    @Transactional
+    public String reIssueRefreshToken(String refreshToken) {
+        User user =  userRepository.findUserByRefreshToken(refreshToken);
+        String newRefreshToken = createRefreshToken(user.getUsername()); // 이름 저장 안하는데 뭘로 조회하는지 -> email 로 오버라이드
+        user.modifyRefreshToken(newRefreshToken);
+        return newRefreshToken;
     }
 
-    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
-        response.setHeader("refreshToken", refreshToken);
+    public String reIssueAccessTokenByRefreshToken(HttpServletResponse response, String refreshToken) {
+        String email = getUserPk(refreshToken, true);
+        return createAccessToken(email);
     }
 }

--- a/src/main/java/tidify/tidify/security/WebSecurityConfig.java
+++ b/src/main/java/tidify/tidify/security/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package tidify.tidify.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -18,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -30,13 +33,14 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.httpBasic()
             .and()
             .authorizeRequests()
+            .antMatchers("/oauth2/**").permitAll()
             .antMatchers("/admin/**").hasRole("ADMIN")
             .antMatchers("/user/**").hasRole("USER")
             .antMatchers("/app/label").permitAll()
             .antMatchers("/app/folders/**").authenticated()
             .antMatchers("/app/bookmarks/**").authenticated()
             .and()
-            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class);
             // JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 전에 넣는다
 
     }

--- a/src/main/java/tidify/tidify/service/AccountService.java
+++ b/src/main/java/tidify/tidify/service/AccountService.java
@@ -1,9 +1,5 @@
 package tidify.tidify.service;
 
-import static tidify.tidify.common.Constants.*;
-
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -34,37 +30,34 @@ public class AccountService {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-
     @Transactional
     public Token getJWTTokens(String idToken, SocialType type) {
         String email = socialLoginFactory.getEmail(type).apply(idToken);
         Token token = jwtTokenProvider.createToken(email);
-        createUser(email, token, type);
+        saveOrUpdateUser(email, token, type);
         return token;
     }
 
-    private void createUser(String userEmail, Token token, SocialType type) {
+    private void saveOrUpdateUser(String userEmail, Token token, SocialType type) {
         userRepository.findUserByEmailAndDelFalse(userEmail)
-            .ifPresentOrElse(
-                existUser -> updateTokens(existUser, token),
+            .ifPresentOrElse(existUser -> updateTokens(existUser, token),
                 () -> saveUser(type, userEmail, token));
     }
 
     private void saveUser(SocialType type, String email, Token token) {
         UserDto userDto = UserDto.of(email, passwordEncoder.encode(email), token);
         User user = socialLoginFactory.getSocialType(type).apply(userDto);
-
-        ValueOperations<String, String> redisOps = redisTemplate.opsForValue();
-        // redisOps.set(token.getRefreshToken(), token.getAccessToken());
-        redisOps.set(token.getRefreshToken(), token.getAccessToken(), REFRESH_TOKEN_VALID_TIME, TimeUnit.MICROSECONDS);
         userRepository.save(user);
     }
 
     private void updateTokens(User user, Token token) {
-        ValueOperations<String, String> redisOps = redisTemplate.opsForValue();
-        redisOps.set(token.getRefreshToken(), token.getAccessToken(), REFRESH_TOKEN_VALID_TIME, TimeUnit.MILLISECONDS);
-
         user.setAccessToken(token.getAccessToken());
         user.setRefreshToken(token.getRefreshToken());
+    }
+
+    private void setTokenRedis(Token token) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        ops.set(token.getRefreshToken(), token.getAccessToken());
+        ops.getAndPersist(token.getRefreshToken());
     }
 }


### PR DESCRIPTION
> ## Purpose
- OAuth2 로그인 과정을 `단일` API URL에서 관리
- OAuth2 회원가입 / 로그인 모두 토큰 발행
- Redis 에 토큰 저장하여 access token / refresh token 탈취 시 대응 방안 고민 -> Redis expiration 문제로 잠시 홀드
- Apple Login : `이메일 공유 / 이메일 가리기` 각 케이스에 따라 추가되는 Property 존재 -> 대응

<br/>

> ## PR 
- QueryDsl 패키지 정리
- 토큰 응답시 Header 명 수정
- Payload property 수정