### PR TITLE
Feature/atdd-domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 /.idea
 src/main/resources/application.yml
 src/main/resources/application-oauth2_client_server.yml
+
+src/main/java/tidify/tidify/common/SecretConstants.java

--- a/src/main/java/tidify/tidify/controller/FolderController.java
+++ b/src/main/java/tidify/tidify/controller/FolderController.java
@@ -41,6 +41,16 @@ public class FolderController {
         return folderService.getFolders(user, pageable);
     }
 
+    @Operation(summary = "개별 폴더 조회", description = "유저의 개별 폴더 조회")
+    @GetMapping("/folder/{folderId}")
+    private ResponseEntity<FolderResponse> getFolders(
+        @AuthenticationPrincipal User user,
+        @PathVariable("folderId") Long folderId
+    ) {
+        FolderResponse folder = folderService.getFolderById(user, folderId);
+        return ResponseEntity.ok().body(folder);
+    }
+
     @Operation(summary="폴더 생성")
     @PostMapping
     private ResponseEntity<FolderResponse> createFolders(

--- a/src/main/java/tidify/tidify/domain/Bookmark.java
+++ b/src/main/java/tidify/tidify/domain/Bookmark.java
@@ -42,8 +42,8 @@ public class Bookmark extends BaseEntity {
     }
 
     public void moidfy(String url, String name, Folder folder) {
-        this.url = url != null ? url : this.url;
-        this.name = name != null ? name : this.name;
+        this.url = url;
+        this.name = name;
         this.folder = folder;
     }
 

--- a/src/main/java/tidify/tidify/dto/BookmarkResponse.java
+++ b/src/main/java/tidify/tidify/dto/BookmarkResponse.java
@@ -9,7 +9,6 @@ import tidify.tidify.domain.Bookmark;
 
 @Getter
 @ToString
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BookmarkResponse {
 
     private Long id;
@@ -49,11 +48,10 @@ public class BookmarkResponse {
         private String name;
         private Long folderId;
 
-        public BookmarkModifyResponse(
-            BookmarkRequest request) {
-            this.url = request.getUrl();
-            this.name = request.getName();
-            this.folderId = request.getFolderId();
+        public BookmarkModifyResponse(Bookmark bookmark) {
+            this.url = bookmark.getUrl();
+            this.name = bookmark.getName();
+            this.folderId = bookmark.getFolder() != null ? bookmark.getFolder().getId() : 0L;
         }
     }
 }

--- a/src/main/java/tidify/tidify/exception/ErrorTypes.java
+++ b/src/main/java/tidify/tidify/exception/ErrorTypes.java
@@ -18,7 +18,8 @@ public enum ErrorTypes {
     METHOD_NOT_ALLOWED("405", "Method Not Allowed Exception"),
 
     // Http Status 5xx (Internal)
-    INTERNAL_SERVER_ERROR("500", "Server Error");
+    INTERNAL_SERVER_ERROR("500", "Server Error"),
+    SQL_VIOLATION_EXCEPTION("520", "SQL Integrity Constraint Violation Exception");
 
     private final String code;
     private final String message;

--- a/src/main/java/tidify/tidify/exception/GlobalExceptionHandler.java
+++ b/src/main/java/tidify/tidify/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package tidify.tidify.exception;
 
+import java.sql.SQLIntegrityConstraintViolationException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -18,5 +21,25 @@ public class GlobalExceptionHandler {
             .build();
         log.error("ResourceNotFoundException(): " + exceptionDto.toString());
         return new ResponseEntity<>(exceptionDto, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(SQLIntegrityConstraintViolationException.class)
+    public final ResponseEntity<?> handleSQLViolationException(SQLIntegrityConstraintViolationException exception) {
+        ExceptionDto exceptionDto = ExceptionDto.builder()
+            .message(exception.getMessage())
+            .errorCode(ErrorTypes.SQL_VIOLATION_EXCEPTION.getCode())
+            .build();
+        log.error("SQLIntegrityConstraintViolationException(): " + exceptionDto.toString());
+        return new ResponseEntity<>(exceptionDto, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public final ResponseEntity<?> handleHttpValidationException(HttpMessageNotReadableException exception) {
+        ExceptionDto exceptionDto = ExceptionDto.builder()
+            .message(exception.getMessage())
+            .errorCode(String.valueOf(HttpStatus.BAD_REQUEST.value()))
+            .build();
+        log.error("HttpMessageNotReadableException(): " + exceptionDto.toString());
+        return new ResponseEntity<>(exceptionDto, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/tidify/tidify/security/JwtTokenProvider.java
+++ b/src/main/java/tidify/tidify/security/JwtTokenProvider.java
@@ -136,6 +136,8 @@ public class JwtTokenProvider {
 
     public String reIssueAccessTokenByRefreshToken(HttpServletResponse response, String refreshToken) {
         String email = getUserPk(refreshToken, true);
-        return createAccessToken(email);
+        String accessToken = createAccessToken(email);
+        log.info("Re-Issued AccessToken : {}", accessToken);
+        return accessToken;
     }
 }

--- a/src/main/java/tidify/tidify/service/FolderService.java
+++ b/src/main/java/tidify/tidify/service/FolderService.java
@@ -1,5 +1,7 @@
 package tidify.tidify.service;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -49,5 +51,10 @@ public class FolderService {
         return folderRepository
             .findFolderByIdAndUser(id, user) // 이미 delete 된 건 못지우게 방어로직 추가
             .orElseThrow(() -> new ResourceNotFoundException(ErrorTypes.FOLDER_NOT_FOUND, id));
+    }
+
+    public FolderResponse getFolderById(User user, Long folderId) {
+        Folder folder = folderRepository.findFolderByIdAndUser(folderId, user).orElseThrow();
+        return FolderResponse.of(folder);
     }
 }

--- a/src/test/java/tidify/tidify/acceptance/BookmarkAcceptanceTest.java
+++ b/src/test/java/tidify/tidify/acceptance/BookmarkAcceptanceTest.java
@@ -1,0 +1,237 @@
+package tidify.tidify.acceptance;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static tidify.tidify.common.SecretConstants.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+@DisplayName("북마크 도메인 인수 테스트")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@Transactional
+public class BookmarkAcceptanceTest {
+
+    /**
+     * given 데이터베이스에 북마크가 저장돼 있을 때,
+     * when 유저의 북마크 목록 조회시
+     * then 북마크의 이름/URL 정보는 항상 존재한다.
+     */
+    @Test
+    void 북마크_조회_테스트() {
+        // given : set up by DB
+
+        // when
+        JsonPath response = 북마크_조회().jsonPath();
+        List<String> 누락_데이터 = Stream.concat(이름이_누락된_북마크(response), URL이_누락된_북마크(response))
+            .toList();
+
+        // then
+        assertThat(누락_데이터).isEmpty();
+    }
+
+    /**
+     * given 북마크의 이름과 URL 이 모두 지정되었을 때
+     * when 북마크를 저장하면
+     * then 북마크가 생성된다.
+     */
+    @Test
+    void 북마크_생성_테스트() {
+        // given
+        String 이름 = "뉴진스의 하입보이요";
+        String URL = "www.google.com";
+        Map<String, Object> data = setUpRequestBody(이름, URL, 0L);
+
+        // when
+        ExtractableResponse<Response> response = 북마크_생성(data);
+        String url = response.jsonPath().get("url");
+        String name = response.jsonPath().get("name");
+
+        // then
+        assertEquals(URL, url);
+        assertEquals(이름, name);
+    }
+
+    /**
+     * given 북마크 생성 시 이름을 null 로 지정하여
+     * when 북마크를 저장하면
+     * then 저장된 북마크의 이름은 url 과 동일하다.
+     */
+    @Test
+    void 북마크_생성_이름_누락_테스트() {
+        // given
+        String 이름 = null;
+        String URL = "www.google.com";
+        Map<String, Object> data = setUpRequestBody(이름, URL, 0L);
+
+        // when
+        ExtractableResponse<Response> response = 북마크_생성(data);
+        String url = response.jsonPath().get("url");
+        String name = response.jsonPath().get("name");
+
+        // then
+        assertThat(url).isEqualTo(name);
+    }
+
+    /**
+     * given 기존 북마크의 이름이 있을 때
+     * when 북마크의 이름을 수정하면
+     * then 수정된 이름이 저장된다.
+     */
+    @Test
+    void 북마크_수정_테스트() {
+        // given
+        String 이름 = "수정된 이름";
+        String URL = "www.google.com";
+        Map<String, Object> data = setUpRequestBody(이름, URL, 0L);
+
+        // when
+        ExtractableResponse<Response> response = 북마크_수정(data);
+
+        // then
+        JsonPath jsonPath = response.jsonPath();
+        String name = jsonPath.get("name");
+        assertEquals(이름, name);
+    }
+
+    /**
+     * given 기존 북마크의 이름이 있을 때
+     * when 북마크의 이름을 지우면
+     * then url 값으로 이름이 저장된다.
+     */
+    @Test
+    void 북마크_이름_NULL_수정_테스트() {
+        // given
+        String 이름 = null;
+        String URL = "www.google.com";
+        Map<String, Object> data = setUpRequestBody(이름, URL, 0L);
+
+        // when
+        ExtractableResponse<Response> response = 북마크_수정(data);
+
+        // then
+        JsonPath jsonPath = response.jsonPath();
+        String name = jsonPath.get("name");
+        assertEquals(URL, name);
+    }
+
+    /**
+     * given 북마크 목록 조회하여 ID 선택,
+     * when 해당 ID 의 북마크를 삭제하면
+     * then 북마크가 삭제된다.
+     */
+    @Test
+    void 북마크_삭제_테스트() {
+        // given
+        List<Integer> 북마크_ID_목록 = 북마크_조회().jsonPath().getList("content.id");
+        int 삭제대상_ID = ID_랜덤_선택(북마크_ID_목록);
+
+        // when
+        ExtractableResponse<Response> response = 북마크_삭제(삭제대상_ID);
+
+        // then
+        int statusCode = response.statusCode();
+        assertThat(HttpStatus.NO_CONTENT.value()).isEqualTo(statusCode);
+    }
+
+    private static int ID_랜덤_선택(List<Integer> 북마크_ID_목록) {
+        int 랜덤_ID = new Random().nextInt(북마크_ID_목록.size());
+        return 북마크_ID_목록.get(랜덤_ID);
+    }
+
+    private static ExtractableResponse<Response> 북마크_삭제(long bookmarkId) {
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .when()
+                .delete("/app/bookmarks/{bookmarkId}", bookmarkId)
+            .then().log().all().extract();
+    }
+
+    private static ExtractableResponse<Response> 북마크_수정(Map<String, Object> body) {
+        Long bookmarkId = 29L;
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .body(body)
+            .when().patch("/app/bookmarks/{bookmarkId}", bookmarkId)
+            .then().log().all().extract();
+    }
+
+    private static ExtractableResponse<Response> 북마크_생성(Map<String, Object> body) {
+
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .body(body)
+            .when().post("/app/bookmarks/")
+            .then().log().all().extract();
+    }
+
+    private static ExtractableResponse<Response> 북마크_조회() {
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .when()
+            .get("/app/bookmarks")
+            .then()
+            .log()
+            .all()
+            .extract();
+    }
+
+    private static Stream<String> URL이_누락된_북마크(JsonPath jsonPath) {
+        return jsonPath.<String>getList("content.url").stream().filter(Objects::isNull);
+    }
+
+    private static Stream<String> 이름이_누락된_북마크(JsonPath jsonPath) {
+        return jsonPath.<String>getList("content.name").stream().filter(Objects::isNull);
+    }
+
+    private Map<String, Object> setUpRequestBody(String name, String url, Long folderId) {
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", name);
+        map.put("url", url);
+        map.put("folderId", folderId);
+
+        return map;
+    }
+
+}

--- a/src/test/java/tidify/tidify/acceptance/FolderAcceptanceTest.java
+++ b/src/test/java/tidify/tidify/acceptance/FolderAcceptanceTest.java
@@ -1,0 +1,203 @@
+package tidify.tidify.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static tidify.tidify.common.SecretConstants.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import tidify.tidify.exception.ErrorTypes;
+
+@DisplayName("폴더 도메인 인수 테스트")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@Transactional
+public class FolderAcceptanceTest {
+
+    /**
+     * given 폴더가 미리 데이터베이스에 저장돼 있을 때,
+     * when 폴더 목록 조회시
+     * then 폴더의 이름과 라벨은 null 이 될 수 없다.
+     */
+    @Test
+    void 폴더의_이름_라벨_반드시_존재() {
+        // given : set up by DB
+
+        // when
+        ExtractableResponse<Response> response = 폴더_조회();
+        List<Object> collect = Stream.concat(이름_누락_폴더(response), 라벨_누락_폴더(response)).toList();
+
+        // then
+        assertThat(collect.size()).isEqualTo(0);
+    }
+
+    /**
+     * given 폴더의 이름과 라벨을 지정하고
+     * when 폴더를 저장하면
+     * then 지정한 이름과 라벨의 폴더가 생성된다.
+     */
+    @Test
+    void 폴더_생성_테스트() {
+        // given
+        Map<String, Object> data = new HashMap<>();
+        String 저장할_폴더명 = "뉴진스의 하입보이요";
+        data.put("folderName", 저장할_폴더명);
+        data.put("label", "GREEN");
+
+        // when
+        ExtractableResponse<Response> response = 폴더_생성(data);
+
+        // then
+        JsonPath jsonPath = response.jsonPath();
+        String 저장된_폴더명 = jsonPath.get("folderName");
+        assertEquals(저장된_폴더명, 저장할_폴더명);
+    }
+
+    /**
+     * given 기존 폴더의
+     * when 이름을 수정하면 + 빈 값으로 수정할 수는 없다.
+     * then 폴더의 이름이 수정된다.
+     */
+    @Test
+    void 폴더_수정_테스트() {
+        // given
+        Map<String, Object> data = new HashMap<>();
+        String 수정할_폴더명 = "Omg";
+        data.put("folderName", 수정할_폴더명);
+        data.put("label", "GREEN");
+
+        // when
+        ExtractableResponse<Response> response = 폴더_수정(data);
+
+        // then
+        JsonPath jsonPath = response.jsonPath();
+        String 수정된_폴더명 = jsonPath.get("folderName");
+        assertEquals(수정된_폴더명, 수정할_폴더명);
+    }
+
+    /**
+     * given 폴더를 생성할 때
+     * when 이름이 누락되면
+     * then 예외를 던진다.
+     */
+    @Test
+    @DisplayName("폴더 생성시 이름이 누락되면 예외를 던진다.")
+    void 이름_누락시_예외발생() {
+
+        // given
+        // Request DTO 의 validation 을 체크하는 필터를 통과하지 않고, 이미 그 후 단계에서부터 시작하는듯.
+        Map<String, Object> data = new HashMap<>();
+        data.put("label", "GREEN");
+
+        // when
+        String statusCode = 폴더_생성(data).jsonPath().get("errorCode");
+
+        // then
+        assertThat(ErrorTypes.SQL_VIOLATION_EXCEPTION.getCode()).isEqualTo((statusCode));
+    }
+
+    /**
+     * given 폴더를 생성할 때
+     * when 라벨이 누락되면
+     * then 예외를 던진다.
+     */
+    @Test
+    @DisplayName("폴더 생성시 라벨이 누락되면 예외를 던진다.")
+    void 라벨_누락시_예외발생() {
+
+        // given
+        // Request DTO 의 validation 을 체크하는 필터를 통과하지 않고, 이미 그 후 단계에서부터 시작하는듯.
+        Map<String, Object> data = new HashMap<>();
+        data.put("folderName", "이름 짓는게 가장 어렵죠");
+
+        // when
+        String statusCode = 폴더_생성(data).jsonPath().get("errorCode");
+
+        // then
+        assertThat(ErrorTypes.SQL_VIOLATION_EXCEPTION.getCode()).isEqualTo((statusCode));
+    }
+
+    private static ExtractableResponse<Response> 폴더_수정(Map<String, Object> body) {
+        Long folderId = 37L;
+
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .body(body)
+            .when().patch("/app/folders/{folderId}", folderId)
+            .then().log().all().extract();
+    }
+
+    private static ExtractableResponse<Response> 폴더_생성(Map<String, Object> body) {
+
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .body(body)
+            .when().post("/app/folders")
+            .then().log().all().extract();
+    }
+
+    private static ExtractableResponse<Response> 폴더_단일_조회(Long folderId) {
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .when().get("/app/folders/folder/{folderId}", folderId)
+            .then().log().all().extract();
+    }
+
+    private static ExtractableResponse<Response> 폴더_조회() {
+        return RestAssured.given().log().all()
+            .headers(
+                "X-Auth-Token",
+                ACCESS_TOKEN,
+                "refreshToken",
+                REFRESH_TOKEN,
+                "Content-Type", ContentType.JSON,
+                "Accept", ContentType.JSON)
+            .when().get("/app/folders/folder")
+            .then().log().all().extract();
+    }
+
+    private static Stream<Object> 라벨_누락_폴더(ExtractableResponse<Response> response) {
+        return response.jsonPath()
+            .getList("content.label.color")
+            .stream()
+            .filter(Objects::isNull);
+    }
+
+    private static Stream<Object> 이름_누락_폴더(ExtractableResponse<Response> response) {
+        return response.jsonPath()
+            .getList("content.folderName")
+            .stream()
+            .filter(Objects::isNull);
+    }
+}


### PR DESCRIPTION
## Purpose
- `Folder`, `Bookmark` 도메인의 인수테스트 작성
- 테스트 작성으로 비즈니스 로직 검증

## PR
- Folder, Bookmark Domain 인수 테스트
- SqlIntegrityConstraintViolationException 예외 핸들로 추가

### 고민
  * #### Domain 
	 * 폴더가 지정되지 않은 Bookmark 는 DTO에선 0L 로 받고 DB엔 null 로 저장 <- 바람직하지 않은 구조, 개선 필요

  * #### Test Code
	 * 테스트용 데이터베이스(ex H2) 별도 구축 필요.
	 * Table constraint 에  name column not null 제약이 이미 있는데, 이게 의미있는 테스트인가?
	 * DB 에 name 이 공백으로 저장돼 있으면 이 테스트는 터지는 것 아닌가? 물론 저장 안되도록 dto validation은 되어 있다.
	* 데이터 생성하려면 시큐리티 뚫어야 하는데, 방법을 더 찾아봐야함.  ->? 이미 뚫려 있자나. 아니 유저 데이터도 만들어야하니까 -> query 직접 실행하면 되는거 아냐?
	* 오히려 실제 적재된 데이터가 있는게 편하다. 내 계정이 생성한 데이터에 한해서만 테스트 돌리면 안되나?
	* Rest Assured 의 Rollback -> H2 DB clean up 
	
