### PR TITLE
feature/folder-share

### DIFF
--- a/src/main/java/tidify/tidify/controller/FolderController.java
+++ b/src/main/java/tidify/tidify/controller/FolderController.java
@@ -2,6 +2,7 @@ package tidify.tidify.controller;
 
 import javax.validation.Valid;
 
+import org.springframework.context.annotation.Description;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import tidify.tidify.domain.FolderSubscribe;
 import tidify.tidify.domain.User;
 import tidify.tidify.dto.CustomPage;
 import tidify.tidify.dto.FolderRequest;
@@ -126,7 +128,7 @@ public class FolderController {
     @PostMapping("/subscribed/{id}")
     private ResponseDto subscribeFolder(
         @AuthenticationPrincipal User user,
-        @RequestBody AuthKey request,
+        @Valid @RequestBody AuthKey request,
         @PathVariable("id") Long folderId
     ) {
 
@@ -135,4 +137,26 @@ public class FolderController {
         return new ObjectResponseDto<>(null);
     }
 
+
+    @Description("구독자 입장 - 구독 취소")
+    @PostMapping("/un-subscribed/{id}")
+    private ResponseDto unSubscribeFolder(
+        @AuthenticationPrincipal User user,
+        @RequestBody AuthKey request,
+        @PathVariable("id") Long folderId
+    ) {
+        String userEmail = jwtTokenProvider.getUserPk(request.getAuthKey(), false);
+        folderService.unSubscribeFolder(folderId, userEmail);
+        return new ObjectResponseDto<>(null);
+    }
+
+    @Description("공유자 입장 - 공유 중지")
+    @PostMapping("/{folderId}/share-suspending")
+    private ResponseDto suspendSharing(
+        @AuthenticationPrincipal User user,
+        @PathVariable(value = "folderId") Long folderId) {
+
+        boolean result = folderService.suspendSharing(user, folderId);
+        return new ObjectResponseDto<>(result);
+    }
 }

--- a/src/main/java/tidify/tidify/controller/FolderController.java
+++ b/src/main/java/tidify/tidify/controller/FolderController.java
@@ -125,32 +125,34 @@ public class FolderController {
         return new ObjectResponseDto<>(response);
     }
 
+
+    @Description("폴더 구독")
     @PostMapping("/subscribed/{id}")
     private ResponseDto subscribeFolder(
         @AuthenticationPrincipal User user,
-        @Valid @RequestBody AuthKey request,
+        // @Valid @RequestBody AuthKey request,
         @PathVariable("id") Long folderId
     ) {
 
-        String userEmail = jwtTokenProvider.getUserPk(request.getAuthKey(), false);
-        folderService.subscribeFolder(folderId, userEmail);
+        // String userEmail = jwtTokenProvider.getUserPk(request.getAuthKey(), false);
+        folderService.subscribeFolder(folderId, user.getUserEmail());
         return new ObjectResponseDto<>(null);
     }
 
 
-    @Description("구독자 입장 - 구독 취소")
+    @Description("폴더 구독 취소")
     @PostMapping("/un-subscribed/{id}")
     private ResponseDto unSubscribeFolder(
         @AuthenticationPrincipal User user,
-        @RequestBody AuthKey request,
+        // @RequestBody AuthKey request,
         @PathVariable("id") Long folderId
     ) {
-        String userEmail = jwtTokenProvider.getUserPk(request.getAuthKey(), false);
-        folderService.unSubscribeFolder(folderId, userEmail);
+        // String userEmail = jwtTokenProvider.getUserPk(request.getAuthKey(), false);
+        folderService.unSubscribeFolder(folderId, user.getUserEmail());
         return new ObjectResponseDto<>(null);
     }
 
-    @Description("공유자 입장 - 공유 중지")
+    @Description("공유자 입장 - 유저 폴더 공유 중지")
     @PostMapping("/{folderId}/share-suspending")
     private ResponseDto suspendSharing(
         @AuthenticationPrincipal User user,

--- a/src/main/java/tidify/tidify/domain/Folder.java
+++ b/src/main/java/tidify/tidify/domain/Folder.java
@@ -59,4 +59,8 @@ public class Folder extends BaseEntity {
     public void toggleStar() {
         this.isStarred = !this.isStarred;
     }
+
+    public void unShare() {
+        this.isShared = false;
+    }
 }

--- a/src/main/java/tidify/tidify/domain/FolderSubscribe.java
+++ b/src/main/java/tidify/tidify/domain/FolderSubscribe.java
@@ -26,4 +26,7 @@ public class FolderSubscribe extends BaseEntity {
     @JoinColumn(name = "folder_id")
     private Folder folder;
 
+    public void unsubscribe() {
+        super.delete();
+    }
 }

--- a/src/main/java/tidify/tidify/dto/AuthKey.java
+++ b/src/main/java/tidify/tidify/dto/AuthKey.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuthKey {
 
-    @NotBlank
     private String authKey;
 
 }

--- a/src/main/java/tidify/tidify/repository/FolderRepositoryCustom.java
+++ b/src/main/java/tidify/tidify/repository/FolderRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface FolderRepositoryCustom {
     Page<FolderResponse> findSubscribingFolders(User user, Pageable pageable);
 
     void subscribeFolder(User user, Long folderId);
+
+    boolean suspendSharing(Long folderId);
 }

--- a/src/main/java/tidify/tidify/repository/FolderSubscribeRepository.java
+++ b/src/main/java/tidify/tidify/repository/FolderSubscribeRepository.java
@@ -1,5 +1,6 @@
 package tidify.tidify.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,5 +15,8 @@ public interface FolderSubscribeRepository extends JpaRepository<FolderSubscribe
 
     boolean existsByUserAndFolder(User user, Folder folder);
 
+    Optional<FolderSubscribe> findByUserAndFolder(User user, Folder folder);
+
+    List<FolderSubscribe> findByFolder(Folder folder);
 }
 

--- a/src/main/java/tidify/tidify/repository/qdsl/FolderRepositoryImpl.java
+++ b/src/main/java/tidify/tidify/repository/qdsl/FolderRepositoryImpl.java
@@ -124,6 +124,18 @@ public class FolderRepositoryImpl implements FolderRepositoryCustom {
             .values(user, folder).execute();
     }
 
+    @Override
+    public boolean suspendSharing(Long folderId) {
+        // 공유 중지하면, 구독자들은 못보게 해야한다 -> del 처리?
+        long execute = query.update(qFolderSubscribe)
+            .set(qFolderSubscribe.del, true)
+            .where(qFolderSubscribe.folder.id.eq(folderId))
+            .execute();
+
+        return execute != 0;
+    }
+
+
     private Page<FolderResponse> queryFolderResponses(Pageable pageable, BooleanExpression whereClause) {
         List<FolderResponse> fetch = getFolderResponse(pageable, whereClause);
 
@@ -154,4 +166,6 @@ public class FolderRepositoryImpl implements FolderRepositoryCustom {
             .where(qBookmark.folder.id.eq(folderId))
             .execute();
     }
+
+
 }

--- a/src/main/java/tidify/tidify/service/FolderService.java
+++ b/src/main/java/tidify/tidify/service/FolderService.java
@@ -140,13 +140,6 @@ public class FolderService {
     public boolean suspendSharing(User user, Long folderId) {
         Folder folder = folderRepository.findById(folderId).orElseThrow();
         folder.unShare();
-        // 해당 폴더를 구독하는 사람들은 보지 못하게 한다.
-        // folderSubscribeRepository.findBy()
-        boolean result = folderRepository.suspendSharing(folderId);
-        return result;
-        // List<FolderSubscribe> byFolder = folderSubscribeRepository.findByFolder(folder);
-        // for (FolderSubscribe folderSubscribe : byFolder) {
-        //
-        // }
+        return folderRepository.suspendSharing(folderId);
     }
 }

--- a/src/main/java/tidify/tidify/service/FolderService.java
+++ b/src/main/java/tidify/tidify/service/FolderService.java
@@ -1,6 +1,6 @@
 package tidify.tidify.service;
 
-import java.sql.Struct;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -120,5 +120,33 @@ public class FolderService {
                 .user(user)
                 .build()
         );
+    }
+
+    @Transactional
+    public FolderSubscribe unSubscribeFolder(Long folderId, String userEmail) {
+        User user = userRepository.findUserByEmailAndDelFalse(userEmail)
+            .orElseThrow();
+        Folder folder = folderRepository.findById(folderId)
+            .orElseThrow();
+
+        FolderSubscribe folderSubscribe = folderSubscribeRepository.findByUserAndFolder(user, folder)
+            .orElseThrow();
+
+        folderSubscribe.unsubscribe();
+        return folderSubscribe;
+    }
+
+    @Transactional
+    public boolean suspendSharing(User user, Long folderId) {
+        Folder folder = folderRepository.findById(folderId).orElseThrow();
+        folder.unShare();
+        // 해당 폴더를 구독하는 사람들은 보지 못하게 한다.
+        // folderSubscribeRepository.findBy()
+        boolean result = folderRepository.suspendSharing(folderId);
+        return result;
+        // List<FolderSubscribe> byFolder = folderSubscribeRepository.findByFolder(folder);
+        // for (FolderSubscribe folderSubscribe : byFolder) {
+        //
+        // }
     }
 }


### PR DESCRIPTION
### Commits
- Folder Share / Un-share / share-suspending API
- Folder 리스트 조회 시, 구독한 폴더인지 필드 추가 필요

### Todo
- 구독한 폴더만 따로 조회하는 API 별도 필요

### Endpoint
- 폴더 공유 중단
    - `app/folders/{folderId}/share-suspending`
- 구독 등록(구독하기/~~팔로우~~ 버튼)
    - `app/folders/subscribed/{id}`
- 구독 취소
    - `app/folders/un-subscribed/{id}`