### PR TITLE
Hotfix/rollback

### DIFF
--- a/src/main/java/tidify/tidify/controller/FolderController.java
+++ b/src/main/java/tidify/tidify/controller/FolderController.java
@@ -93,6 +93,18 @@ public class FolderController {
         return new PageResponseDto<>(folderWithBookmarks);
     }
 
+    @Description("구독한 폴더의 북마크 조회")
+    @GetMapping("/{folderId}/bookmarks/shared")
+    private ResponseDto getSharedFolderWithBookmarks(
+        @AuthenticationPrincipal User user,
+        @PathVariable("folderId") Long folderId,
+        Pageable pageable
+    ) {
+        CustomPage folderWithBookmarks = folderService.getSharedFolderWithBookmarks(user, folderId,
+            pageable);
+        return new PageResponseDto<>(folderWithBookmarks);
+    }
+
     @PatchMapping("/{folderId}")
     private ResponseDto modifyFolders(
         @AuthenticationPrincipal User user,

--- a/src/main/java/tidify/tidify/controller/FolderController.java
+++ b/src/main/java/tidify/tidify/controller/FolderController.java
@@ -54,6 +54,7 @@ public class FolderController {
         return new PageResponseDto<>(folders);
     }
 
+    @Description("(나의) 공유중인 폴더)")
     @GetMapping("/subscribing")
     private ResponseDto getSubscribingFolders(
         @AuthenticationPrincipal User user,
@@ -118,6 +119,7 @@ public class FolderController {
         return new ObjectResponseDto<>(myFolder);
     }
 
+    @Description("폴더 생성")
     @PostMapping
     private ResponseDto createFolders(
         @AuthenticationPrincipal User user, @Valid @RequestBody FolderRequest request) {
@@ -130,11 +132,8 @@ public class FolderController {
     @PostMapping("/subscribed/{id}")
     private ResponseDto subscribeFolder(
         @AuthenticationPrincipal User user,
-        // @Valid @RequestBody AuthKey request,
         @PathVariable("id") Long folderId
     ) {
-
-        // String userEmail = jwtTokenProvider.getUserPk(request.getAuthKey(), false);
         folderService.subscribeFolder(folderId, user.getUserEmail());
         return new ObjectResponseDto<>(null);
     }
@@ -144,10 +143,8 @@ public class FolderController {
     @PostMapping("/un-subscribed/{id}")
     private ResponseDto unSubscribeFolder(
         @AuthenticationPrincipal User user,
-        // @RequestBody AuthKey request,
         @PathVariable("id") Long folderId
     ) {
-        // String userEmail = jwtTokenProvider.getUserPk(request.getAuthKey(), false);
         folderService.unSubscribeFolder(folderId, user.getUserEmail());
         return new ObjectResponseDto<>(null);
     }
@@ -158,7 +155,7 @@ public class FolderController {
         @AuthenticationPrincipal User user,
         @PathVariable(value = "folderId") Long folderId) {
 
-        boolean result = folderService.suspendSharing(user, folderId);
+        boolean result = folderService.stopSharing(user, folderId);
         return new ObjectResponseDto<>(result);
     }
 }

--- a/src/main/java/tidify/tidify/domain/Folder.java
+++ b/src/main/java/tidify/tidify/domain/Folder.java
@@ -63,4 +63,9 @@ public class Folder extends BaseEntity {
     public void unShare() {
         this.isShared = false;
     }
+
+    public void share() {
+        this.isShared = true;
+    }
+
 }

--- a/src/main/java/tidify/tidify/repository/FolderRepositoryCustom.java
+++ b/src/main/java/tidify/tidify/repository/FolderRepositoryCustom.java
@@ -12,6 +12,8 @@ public interface FolderRepositoryCustom {
 
     Page<BookmarkResponse> findBookmarksByFolder(User user, Long folderId, Pageable pageable);
 
+    Page<BookmarkResponse> findBookmarksBySharedFolder(User user, Long folderId, Pageable pageable);
+
     Page<FolderResponse> findSubscribedFolders(User user, Pageable pageable);
 
     Page<FolderResponse> findSubscribingFolders(User user, Pageable pageable);

--- a/src/main/java/tidify/tidify/repository/FolderRepositoryCustom.java
+++ b/src/main/java/tidify/tidify/repository/FolderRepositoryCustom.java
@@ -18,5 +18,5 @@ public interface FolderRepositoryCustom {
 
     void subscribeFolder(User user, Long folderId);
 
-    boolean suspendSharing(Long folderId);
+    boolean stopSharing(Long folderId);
 }

--- a/src/main/java/tidify/tidify/repository/FolderSubscribeRepository.java
+++ b/src/main/java/tidify/tidify/repository/FolderSubscribeRepository.java
@@ -13,9 +13,9 @@ import tidify.tidify.domain.User;
 @Repository
 public interface FolderSubscribeRepository extends JpaRepository<FolderSubscribe, Long> {
 
-    boolean existsByUserAndFolder(User user, Folder folder);
+    boolean existsByUserAndFolderAndDel(User user, Folder folder, Boolean isDel);
 
-    Optional<FolderSubscribe> findByUserAndFolder(User user, Folder folder);
+    Optional<FolderSubscribe> findByUserAndFolderAndDel(User user, Folder folder, Boolean isDel);
 
     List<FolderSubscribe> findByFolder(Folder folder);
 }

--- a/src/main/java/tidify/tidify/repository/qdsl/FolderRepositoryImpl.java
+++ b/src/main/java/tidify/tidify/repository/qdsl/FolderRepositoryImpl.java
@@ -106,9 +106,9 @@ public class FolderRepositoryImpl implements FolderRepositoryCustom {
 
         return query.select(new QFolderResponse(qFolder, qFolderSubscribe.count()))
             .from(qFolder)
-            .where(whereCondition)
             .leftJoin(qFolderSubscribe)
             .on(qFolder.eq(qFolderSubscribe.folder))
+            .where(whereCondition)
             .groupBy(qFolder)
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -125,7 +125,7 @@ public class FolderRepositoryImpl implements FolderRepositoryCustom {
     }
 
     @Override
-    public boolean suspendSharing(Long folderId) {
+    public boolean stopSharing(Long folderId) {
         // 공유 중지하면, 구독자들은 못보게 해야한다 -> del 처리?
         long execute = query.update(qFolderSubscribe)
             .set(qFolderSubscribe.del, true)

--- a/src/main/java/tidify/tidify/service/FolderService.java
+++ b/src/main/java/tidify/tidify/service/FolderService.java
@@ -113,7 +113,7 @@ public class FolderService {
         if (isOwnFolder(user, folder)) {
             return;
         }
-        if (folderSubscribeRepository.existsByUserAndFolder(user, folder)) {
+        if (folderSubscribeRepository.existsByUserAndFolderAndDel(user, folder, false)) {
             return;
         }
 
@@ -133,7 +133,7 @@ public class FolderService {
         Folder folder = folderRepository.findById(folderId)
             .orElseThrow();
 
-        FolderSubscribe folderSubscribe = folderSubscribeRepository.findByUserAndFolder(user, folder)
+        FolderSubscribe folderSubscribe = folderSubscribeRepository.findByUserAndFolderAndDel(user, folder, false)
             .orElseThrow();
 
         folderSubscribe.unsubscribe();
@@ -149,5 +149,10 @@ public class FolderService {
 
     private boolean isOwnFolder(User user, Folder folder) {
         return Objects.equals(folder.getUser().getId(), user.getId());
+    }
+
+    public CustomPage getSharedFolderWithBookmarks(User user, Long folderId, Pageable pageable) {
+        Page<BookmarkResponse> bookmarks = folderRepository.findBookmarksBySharedFolder(user, folderId, pageable);
+        return CustomPage.of(bookmarks);
     }
 }


### PR DESCRIPTION
### Commits
- springboot3 -> 2.7.8 : docker 빌드가 안되는 이슈...
- 구독한 폴더의 북마크 조회 API 추가
  - folder_subscribe 테이블에서 user_id, folder_id, del=false 조건으로 조회
  - 데이터 존재시 구독한 것으로 판단하여, folder_id 로 북마크 테이블 조회


### Issue
`상황`
- 구독 취소 시 folder_subscribe.del = true 로 update
- 재구독 후 조회 시, 조회되지 않는 이슈 발생

`원인`
- 폴더 구독 API 에서 folder_subscribe 에 기존의 데이터가 존재하면 얼리 리턴 시켜버림. 
- folder_subscribe 조회 시 del 조건을 predicate 로 넣지 않아서 발생한 문제

`해결`
- folder_subscribe 조회 시 del 조건을 where 절에 추가.